### PR TITLE
feat: Configure app launcher icons using flutter_launcher_icons

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^5.0.0 # Consider updating if very old, but usually fine
+  flutter_launcher_icons: ^0.13.1
 
 flutter:
   uses-material-design: true
@@ -39,3 +40,9 @@ flutter:
     # I'm opting for directory inclusion for products and agregados for simplicity.
     # If only R9.png is needed from logos, then 'assets/images/logos/R9.png' is better than 'assets/images/logos/'.
     # For now, I'll keep 'assets/images/logos/' to include all logos if more exist.
+
+# New configuration block for flutter_launcher_icons
+flutter_launcher_icons:
+  android: true
+  ios: true
+  image_path: "assets/images/logos/R9.png"


### PR DESCRIPTION
I've added `flutter_launcher_icons` to `dev_dependencies` and configured it in `pubspec.yaml` to use `assets/images/logos/R9.png` as the source image for generating platform-specific launcher icons for Android and iOS.

The following was added to `pubspec.yaml`:

In `dev_dependencies`:
  flutter_launcher_icons: ^0.13.1

At the root level:
flutter_launcher_icons:
  android: true
  ios: true
  image_path: "assets/images/logos/R9.png"

To generate the icons after these changes, you'll need to run:
1. `flutter pub get`
2. `flutter pub run flutter_launcher_icons`