### PR TITLE
fix: Add provider package to dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   font_awesome_flutter: ^10.7.0
   csv: ^5.1.1
   google_fonts: ^6.2.1
+  provider: ^6.1.2 # Added line
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Added the `provider` package (`^6.1.2`) to the `dependencies` section in `pubspec.yaml`.

This was missing and caused build failures due to unresolved imports for `package:provider/provider.dart` and undefined Provider-related methods (e.g., `ChangeNotifierProvider`, `context.watch`).

Adding this dependency is essential for the cart functionality, which utilizes `ChangeNotifier` and `ChangeNotifierProvider` for state management.

You need to run `flutter pub get` after this change.