### PR TITLE
fix: Add HTTPS intent query to AndroidManifest.xml

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -37,5 +37,9 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
     </queries>
 </manifest>


### PR DESCRIPTION
Added an `<intent>` filter for `android.intent.action.VIEW` with `android:scheme="https"` to the `<queries>` block in `android/app/src/main/AndroidManifest.xml`.

This change is necessary for apps targeting Android 11 (API level 30) and higher to declare their intent to interact with apps capable of handling HTTPS links (e.g., web browsers). This should help resolve issues where `url_launcher`'s `canLaunchUrl` might return `false` for HTTPS URLs on such devices due to package visibility restrictions.