### PR TITLE
I refined the entry animation for `ProductCard` widgets in the `MenuR…

### DIFF
--- a/lib/screens/menur9zonafranca.dart
+++ b/lib/screens/menur9zonafranca.dart
@@ -79,7 +79,6 @@ class _MenuR9ZonaFrancaScreenState extends State<MenuR9ZonaFrancaScreen> with Si
   }
 
   void _handleProductInteraction(Product product) {
-    // Corrected line:
     showDialog<dynamic>( context: context, builder: (BuildContext dialogContext) { return ProductDetailDialog(product: product); },
     ).then((result) {
       if (result == true) {
@@ -90,10 +89,8 @@ class _MenuR9ZonaFrancaScreenState extends State<MenuR9ZonaFrancaScreen> with Si
     });
   }
 
-
   @override
   Widget build(BuildContext context) {
-    // Added a null check for _tabController before accessing its length or properties
     bool showTabBar = _tabController != null &&
                       _tabController!.length > 0 &&
                       !(_tabController!.length == 1 && _tabCategories.first == "TODOS" && _allZonaFrancaProducts.isEmpty);
@@ -119,17 +116,12 @@ class _MenuR9ZonaFrancaScreenState extends State<MenuR9ZonaFrancaScreen> with Si
   Widget _buildBody() {
     if (_isLoading) { return const Center(child: CircularProgressIndicator()); }
     if (_error != null) { return Center(child: Padding(padding: const EdgeInsets.all(16.0), child: Text(_error!, style: Theme.of(context).textTheme.titleMedium?.copyWith(color: Colors.red), textAlign: TextAlign.center,),),); }
-
-    // Simplified condition for showing "No products" message
     if (_allZonaFrancaProducts.isEmpty) {
          return Center(child: Text('No hay productos disponibles para Zona Franca.', style: Theme.of(context).textTheme.titleMedium, textAlign: TextAlign.center,));
     }
-    // If _tabController is null (can happen briefly or on error during init), show loading or empty.
-    // This check is important before TabBarView.
     if (_tabController == null) {
-        return const Center(child: CircularProgressIndicator()); // Or an appropriate empty/error message
+        return const Center(child: CircularProgressIndicator());
     }
-
 
     return TabBarView(
       key: ValueKey(_tabCategories.join('-')),
@@ -139,7 +131,6 @@ class _MenuR9ZonaFrancaScreenState extends State<MenuR9ZonaFrancaScreen> with Si
             ? _allZonaFrancaProducts
             : (_productsByCategory[category] ?? []);
 
-        // Simplified empty message logic within TabBarView child
         if (productsToShow.isEmpty) {
              return Center(child: Text('No hay productos en la categoría ${category.toUpperCase()}.', style: Theme.of(context).textTheme.titleMedium));
         }
@@ -159,13 +150,13 @@ class _MenuR9ZonaFrancaScreenState extends State<MenuR9ZonaFrancaScreen> with Si
             return TweenAnimationBuilder<double>(
               key: ValueKey(product.id),
               tween: Tween<double>(begin: 0.0, end: 1.0),
-              duration: Duration(milliseconds: 300 + (index % 5 * 100)),
-              curve: Curves.easeOut,
+              duration: const Duration(milliseconds: 500), // MODIFIED
+              curve: Curves.easeOutCubic, // MODIFIED
               builder: (BuildContext context, double value, Widget? child) {
                 return Opacity(
                   opacity: value,
                   child: Transform.translate(
-                    offset: Offset(0, (1.0 - value) * 30),
+                    offset: Offset(0, (1.0 - value) * 20), // MODIFIED (30 to 20)
                     child: child,
                   ),
                 );


### PR DESCRIPTION
…9ZonaFrancaScreen`'s `GridView.builder`.

Changes to the `TweenAnimationBuilder` parameters include:
-   **Duration**: Changed from a variable, staggered duration to a uniform `Duration(milliseconds: 500)` for all items. This provides a more consistent animation speed per card.
-   **Curve**: Updated from `Curves.easeOut` to `Curves.easeOutCubic` for a smoother and more pronounced easing effect.
-   **Transform Offset**: Reduced the initial vertical slide-up distance from 30px to 20px (`(1.0 - value) * 20`), making the animation more subtle.

These adjustments aim to create a cleaner, more polished, and visually consistent entry animation for product cards as they appear on the menu, contributing to an improved user experience. The staggering of animations will now primarily occur naturally as items are built by the `GridView` during scrolling.