### PR TITLE
feat: Implement UI mockups for account features & add favorite icon t…

### DIFF
--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -1,0 +1,112 @@
+// lib/screens/auth/login_screen.dart
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import '../../core/constants/colors.dart'; // For AppColors if needed for specific styling
+
+class LoginScreen extends StatelessWidget {
+  const LoginScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme textTheme = Theme.of(context).textTheme;
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      // Potentially an AppBar if needed, or keep it minimal
+      // appBar: AppBar(
+      //   title: const Text('Iniciar Sesión'),
+      //   elevation: 0,
+      //   backgroundColor: Colors.transparent, // Or from theme
+      // ),
+      backgroundColor: AppColors.primaryDark, // Match the app's dark theme background
+      body: Center(
+        child: SingleChildScrollView( // In case content overflows on small screens
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              // App Logo
+              Image.asset(
+                'assets/images/logos/R9.png',
+                height: 100, // Adjust size as needed
+                // width: 100,
+              ),
+              const SizedBox(height: 24.0),
+
+              // Welcome Message
+              Text(
+                'Bienvenido a Ruta9',
+                textAlign: TextAlign.center,
+                style: textTheme.headlineMedium?.copyWith(color: AppColors.textLight),
+              ),
+              const SizedBox(height: 8.0),
+              Text(
+                'Inicia sesión para continuar',
+                textAlign: TextAlign.center,
+                style: textTheme.titleMedium?.copyWith(color: AppColors.textMuted),
+              ),
+              const SizedBox(height: 48.0),
+
+              // Sign in with Google Button
+              ElevatedButton.icon(
+                icon: const FaIcon(FontAwesomeIcons.google, color: Colors.white, size: 20),
+                label: Text(
+                  'Iniciar Sesión con Google',
+                  style: textTheme.labelLarge?.copyWith(color: Colors.white, fontSize: 16),
+                ),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.primaryRed, // Or a Google-like blue: Color(0xFF4285F4)
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 14.0),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8.0),
+                  ),
+                  elevation: 2,
+                ),
+                onPressed: () {
+                  // Placeholder action for Google Sign-In
+                  print('Google Sign-In button pressed (Not Implemented)');
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Funcionalidad de inicio de sesión con Google (pendiente).'),
+                      duration: Duration(seconds: 2),
+                    ),
+                  );
+                  // In a real app, this would trigger the Google Sign-In flow
+                  // and on success, navigate to the main app or profile screen.
+                  // For now, maybe pop back if shown as a dialog/modal, or do nothing.
+                  // If LoginScreen is a full page, it might navigate on success.
+                  // Navigator.of(context).pop(); // Example if presented modally
+                },
+              ),
+              const SizedBox(height: 24.0),
+
+              // Optional: "Or sign in with email" or other methods
+              // Text(
+              //   'O',
+              //   textAlign: TextAlign.center,
+              //   style: textTheme.bodyMedium?.copyWith(color: AppColors.textMuted),
+              // ),
+              // const SizedBox(height: 16.0),
+              // Placeholder for email/password login if ever needed
+
+              // Optional: Skip login / Continue as guest
+              // TextButton(
+              //   onPressed: () {
+              //     // Navigate to main app as guest or pop
+              //     print('Skip login pressed');
+              //     Navigator.of(context).pop(); // Example
+              //   },
+              //   child: Text(
+              //     'Continuar como invitado',
+              //     style: textTheme.bodyMedium?.copyWith(color: AppColors.primaryRed),
+              //   ),
+              // ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/profile/favorites_screen_placeholder.dart
+++ b/lib/views/profile/favorites_screen_placeholder.dart
@@ -1,0 +1,26 @@
+// lib/views/profile/favorites_screen_placeholder.dart
+import 'package:flutter/material.dart';
+
+class FavoritesScreenPlaceholder extends StatelessWidget {
+  const FavoritesScreenPlaceholder({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Mis Favoritos'),
+        // leading: IconButton( // Enable if direct back navigation is desired
+        //   icon: Icon(Icons.arrow_back),
+        //   onPressed: () => Navigator.of(context).pop(),
+        // ),
+      ),
+      body: Center(
+        child: Text(
+          'Contenido de Favoritos (Próximamente)',
+          style: Theme.of(context).textTheme.headlineSmall,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/profile/order_history_screen_placeholder.dart
+++ b/lib/views/profile/order_history_screen_placeholder.dart
@@ -1,0 +1,22 @@
+// lib/views/profile/order_history_screen_placeholder.dart
+import 'package:flutter/material.dart';
+
+class OrderHistoryScreenPlaceholder extends StatelessWidget {
+  const OrderHistoryScreenPlaceholder({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Historial de Pedidos'),
+      ),
+      body: Center(
+        child: Text(
+          'Contenido de Historial de Pedidos (Próximamente)',
+          style: Theme.of(context).textTheme.headlineSmall,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/profile/payment_methods_screen_placeholder.dart
+++ b/lib/views/profile/payment_methods_screen_placeholder.dart
@@ -1,0 +1,22 @@
+// lib/views/profile/payment_methods_screen_placeholder.dart
+import 'package:flutter/material.dart';
+
+class PaymentMethodsScreenPlaceholder extends StatelessWidget {
+  const PaymentMethodsScreenPlaceholder({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Métodos de Pago'),
+      ),
+      body: Center(
+        child: Text(
+          'Contenido de Métodos de Pago (Próximamente)',
+          style: Theme.of(context).textTheme.headlineSmall,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/profile/profile_placeholder_view.dart
+++ b/lib/views/profile/profile_placeholder_view.dart
@@ -1,39 +1,64 @@
 // lib/views/profile/profile_placeholder_view.dart
 import 'package:flutter/material.dart';
+import '../../screens/auth/login_screen.dart'; // Import the LoginScreen
+import '../../core/constants/colors.dart'; // For button styling if needed
 
 class ProfilePlaceholderView extends StatelessWidget {
   const ProfilePlaceholderView({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final TextTheme textTheme = Theme.of(context).textTheme;
+    // final ColorScheme colorScheme = Theme.of(context).colorScheme;
+
     return Scaffold(
-      // Adding an AppBar to placeholders for a more complete look within the shell
       appBar: AppBar(
         title: const Text('Mi Perfil'),
-        automaticallyImplyLeading: false, // No back button if it's a main tab view
+        automaticallyImplyLeading: false,
       ),
       body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.person_search,
-              size: 80,
-              color: Theme.of(context).textTheme.bodyLarge?.color?.withOpacity(0.4)
-            ),
-            const SizedBox(height: 20),
-            Text(
-              'Contenido del Perfil',
-              style: Theme.of(context).textTheme.headlineSmall,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              '(Próximamente disponible)',
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                color: Theme.of(context).textTheme.bodyLarge?.color?.withOpacity(0.6)
+        child: Padding( // Added padding around the content
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                Icons.person_off_outlined, // Changed icon to reflect "not logged in"
+                size: 80,
+                color: textTheme.bodyLarge?.color?.withOpacity(0.4)
               ),
-            ),
-          ],
+              const SizedBox(height: 20),
+              Text(
+                'Accede a tu Cuenta', // Changed title
+                style: textTheme.headlineSmall,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Inicia sesión o regístrate para ver tu perfil, favoritos y más.', // Changed subtitle
+                style: textTheme.titleMedium?.copyWith(
+                  color: textTheme.bodyLarge?.color?.withOpacity(0.6)
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 32), // Added more space before button
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  // backgroundColor: AppColors.primaryRed, // From theme
+                  // foregroundColor: Colors.white, // From theme
+                  padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 12),
+                  textStyle: textTheme.labelLarge?.copyWith(fontSize: 16),
+                ),
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) => const LoginScreen()),
+                  );
+                },
+                child: const Text('Iniciar Sesión / Registrarse'),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/views/profile/profile_screen.dart
+++ b/lib/views/profile/profile_screen.dart
@@ -1,0 +1,129 @@
+// lib/views/profile/profile_screen.dart
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import '../../core/constants/colors.dart';
+
+// Import the new placeholder screens
+import 'favorites_screen_placeholder.dart';
+import 'order_history_screen_placeholder.dart';
+import 'payment_methods_screen_placeholder.dart';
+// (Assuming LoginScreen might be needed for logout, ensure it's imported if not already)
+import '../../screens/auth/login_screen.dart';
+
+
+// Remove the local _navigateToPlaceholder function:
+// void _navigateToPlaceholder(BuildContext context, String title) { ... } // DELETE THIS
+
+class ProfileScreen extends StatelessWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme textTheme = Theme.of(context).textTheme;
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+
+    const String userName = "Usuario Ruta9";
+    const String userEmail = "usuario@ruta9.app";
+    const String profileImageUrl = "";
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Mi Perfil'),
+        automaticallyImplyLeading: false,
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(0),
+        children: <Widget>[
+          Container(
+            padding: const EdgeInsets.all(24.0),
+            color: AppColors.surfaceDark,
+            child: Column(
+              children: [
+                CircleAvatar(
+                  radius: 50,
+                  backgroundColor: AppColors.primaryRed.withOpacity(0.7),
+                  backgroundImage: profileImageUrl.isNotEmpty ? NetworkImage(profileImageUrl) : null,
+                  child: profileImageUrl.isEmpty
+                      ? const FaIcon(FontAwesomeIcons.userAstronaut, size: 50, color: AppColors.textLight)
+                      : null,
+                ),
+                const SizedBox(height: 16),
+                Text(userName, style: textTheme.headlineSmall?.copyWith(color: AppColors.textLight)),
+                const SizedBox(height: 4),
+                Text(userEmail, style: textTheme.titleMedium?.copyWith(color: AppColors.textMuted)),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+
+          _buildProfileOptionTile(
+            context: context,
+            icon: FontAwesomeIcons.heart,
+            title: 'Mis Favoritos',
+            onTap: () {
+              Navigator.push(context, MaterialPageRoute(builder: (_) => const FavoritesScreenPlaceholder()));
+            },
+          ),
+          _buildProfileOptionTile(
+            context: context,
+            icon: FontAwesomeIcons.receipt,
+            title: 'Historial de Pedidos',
+            onTap: () {
+              Navigator.push(context, MaterialPageRoute(builder: (_) => const OrderHistoryScreenPlaceholder()));
+            },
+          ),
+          _buildProfileOptionTile(
+            context: context,
+            icon: FontAwesomeIcons.creditCard,
+            title: 'Métodos de Pago',
+            onTap: () {
+              Navigator.push(context, MaterialPageRoute(builder: (_) => const PaymentMethodsScreenPlaceholder()));
+            },
+          ),
+          _buildProfileOptionTile(
+            context: context,
+            icon: Icons.settings_outlined,
+            title: 'Configuración',
+            onTap: () {
+              Navigator.push( context, MaterialPageRoute( builder: (context) => Scaffold( appBar: AppBar(title: const Text('Configuración')), body: Center(child: Text('Configuración (Próximamente)', style: Theme.of(context).textTheme.headlineSmall)),),),);
+            },
+          ),
+          const Divider(height: 32, indent: 16, endIndent: 16),
+          _buildProfileOptionTile(
+            context: context,
+            icon: Icons.logout,
+            title: 'Cerrar Sesión',
+            textColor: colorScheme.error,
+            onTap: () {
+              print('Logout button pressed');
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Cerrar Sesión (pendiente).')),
+              );
+              Navigator.of(context).pushAndRemoveUntil(
+                MaterialPageRoute(builder: (context) => const LoginScreen()),
+                (Route<dynamic> route) => false,
+              );
+            },
+          ),
+          const SizedBox(height: 16),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildProfileOptionTile({
+    required BuildContext context,
+    required IconData icon,
+    required String title,
+    required VoidCallback onTap,
+    Color? textColor,
+  }) {
+    final TextTheme textTheme = Theme.of(context).textTheme;
+    return ListTile(
+      leading: FaIcon(icon, color: textColor ?? textTheme.bodyLarge?.color?.withOpacity(0.7), size: 22),
+      title: Text(title, style: textTheme.titleMedium?.copyWith(color: textColor)),
+      trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+      onTap: onTap,
+    );
+  }
+}

--- a/lib/widgets/product_card.dart
+++ b/lib/widgets/product_card.dart
@@ -1,9 +1,11 @@
+// lib/widgets/product_card.dart
 import 'package:flutter/material.dart';
 import '../models/product_model.dart';
-// AppColors is not strictly needed if all colors come from theme, but kept for consistency if used by placeholder
 import '../core/constants/colors.dart';
+import 'tap_scale_wrapper.dart'; // Assuming TapScaleWrapper is available for button animation
 
-class ProductCard extends StatelessWidget {
+// Changed to StatefulWidget to manage favorite state locally
+class ProductCard extends StatefulWidget {
   final Product product;
   final VoidCallback? onAddButtonPressed;
   final VoidCallback? onTap;
@@ -15,73 +17,94 @@ class ProductCard extends StatelessWidget {
     this.onTap,
   });
 
+  @override
+  State<ProductCard> createState() => _ProductCardState();
+}
+
+class _ProductCardState extends State<ProductCard> {
+  bool _isFavorite = false; // Local state for favorite toggle
+
   String _getImagePath(Product product) {
     String imageName = product.imagen ?? "";
-    if (imageName.isEmpty) {
-      imageName = '${product.id.toLowerCase().replaceAll(' ', '_')}.jpg';
-    } else if (!imageName.toLowerCase().endsWith('.jpg') && !imageName.toLowerCase().endsWith('.png')) {
-      imageName += '.jpg';
-    }
+    if (imageName.isEmpty) { imageName = '${product.id.toLowerCase().replaceAll(' ', '_')}.jpg';}
+    else if (!imageName.toLowerCase().endsWith('.jpg') && !imageName.toLowerCase().endsWith('.png')) { imageName += '.jpg';}
     String categoryPath = product.subcategoria?.toLowerCase().replaceAll(' ', '_') ?? 'general';
     String basePath = 'assets/images/products/';
     if (categoryPath.contains('burger')) { basePath += 'burgers/'; }
     else if (categoryPath.contains('sandwich')) { basePath += 'sandwiches/'; }
-    else if (categoryPath.contains('combo')) { basePath += 'combos/'; } // Added for COMBOS
+    else if (categoryPath.contains('combo')) { basePath += 'combos/'; }
     else if (categoryPath.contains('snack') || categoryPath.contains('acompañamiento')) { basePath += 'snacks/'; }
     else if (categoryPath.contains('bebida')) { basePath += 'bebidas/'; }
     else { basePath += 'general/'; }
     return '$basePath$imageName';
   }
 
+  void _toggleFavorite() {
+    setState(() {
+      _isFavorite = !_isFavorite;
+    });
+    print('Favorite toggled for ${widget.product.id}: $_isFavorite (UI only)');
+    // In a real app, this would also call a provider/service to update backend/local persistence
+  }
+
   @override
   Widget build(BuildContext context) {
     final TextTheme textTheme = Theme.of(context).textTheme;
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
-    // CardTheme is applied by the global theme.
-    // final CardTheme cardTheme = Theme.of(context).cardTheme;
-
-    final String imagePath = _getImagePath(product);
+    final String imagePath = _getImagePath(widget.product);
 
     return Card(
-      // Using properties from AppTheme.cardTheme by default
-      // Consider specifying margin here if CategorySection doesn't provide enough spacing
-      // margin: const EdgeInsets.symmetric(horizontal: 4.0, vertical: 4.0), // Example if needed
-      clipBehavior: Clip.antiAlias, // Ensures content respects card's rounded corners
+      clipBehavior: Clip.antiAlias,
       child: InkWell(
-        onTap: onTap,
-        // borderRadius: BorderRadius.circular(12.0), // Already handled by Card's shape if InkWell is direct child
+        onTap: widget.onTap,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: <Widget>[
-            // Product Image
             Expanded(
               flex: 3,
-              child: Hero( // MODIFIED: Added Hero widget
-                tag: 'hero_product_image_${product.id}', // Unique tag per product
-                child: ClipRRect(
-                  borderRadius: const BorderRadius.only(
-                    topLeft: Radius.circular(12.0),
-                    topRight: Radius.circular(12.0),
-                  ),
-                  child: Image.asset(
-                    imagePath,
-                    fit: BoxFit.cover,
-                    errorBuilder: (context, error, stackTrace) {
-                      return Container(
-                        alignment: Alignment.center,
-                        color: AppColors.surfaceDark.withOpacity(0.8),
-                        child: Icon(
-                          Icons.fastfood,
-                          color: AppColors.textMuted.withOpacity(0.6),
-                          size: 40,
+              child: Stack( // Use Stack to overlay favorite button on image
+                children: [
+                  Positioned.fill(
+                    child: Hero(
+                      tag: 'hero_product_image_${widget.product.id}',
+                      child: ClipRRect(
+                        borderRadius: const BorderRadius.only(
+                          topLeft: Radius.circular(12.0),
+                          topRight: Radius.circular(12.0),
                         ),
-                      );
-                    },
+                        child: Image.asset(
+                          imagePath,
+                          fit: BoxFit.cover,
+                          errorBuilder: (context, error, stackTrace) {
+                            return Container( alignment: Alignment.center, color: AppColors.surfaceDark.withOpacity(0.8), child: Icon( Icons.fastfood, color: AppColors.textMuted.withOpacity(0.6), size: 40, ), );
+                           },
+                        ),
+                      ),
+                    ),
                   ),
-                ),
+                  Positioned( // Favorite button
+                    top: 8,
+                    right: 8,
+                    child: Material( // Material for InkWell splash and shape
+                      color: AppColors.backgroundDark.withOpacity(0.4),
+                      shape: const CircleBorder(),
+                      clipBehavior: Clip.antiAlias,
+                      child: IconButton(
+                        icon: Icon(
+                          _isFavorite ? Icons.favorite : Icons.favorite_border,
+                          color: _isFavorite ? colorScheme.primary : AppColors.textLight.withOpacity(0.9),
+                        ),
+                        iconSize: 24, // Adjust size as needed
+                        padding: const EdgeInsets.all(6), // Adjust padding for touch area
+                        constraints: const BoxConstraints(), // Remove default IconButton padding
+                        tooltip: _isFavorite ? 'Quitar de Favoritos' : 'Agregar a Favoritos',
+                        onPressed: _toggleFavorite,
+                      ),
+                    ),
+                  ),
+                ],
               ),
             ),
-            // Product Details
             Expanded(
               flex: 2,
               child: Padding(
@@ -93,30 +116,21 @@ class ProductCard extends StatelessWidget {
                     Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(
-                          product.nombre,
-                          style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                            fontWeight: FontWeight.bold,
-                          ),
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                        ),
+                        Text( widget.product.nombre, style: textTheme.titleMedium?.copyWith( fontWeight: FontWeight.bold,), maxLines: 2, overflow: TextOverflow.ellipsis, ),
                         const SizedBox(height: 4),
-                        Text(
-                          '\$${product.precio.toStringAsFixed(0)}',
-                          style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                            color: Theme.of(context).colorScheme.secondary,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
+                        Text( '\$${widget.product.precio.toStringAsFixed(0)}', style: textTheme.titleMedium?.copyWith( color: colorScheme.secondary, fontWeight: FontWeight.bold, ), ),
                       ],
                     ),
                     const SizedBox(height: 8),
                     SizedBox(
                       width: double.infinity,
-                      child: ElevatedButton(
-                        onPressed: onAddButtonPressed,
-                        child: const Text('Agregar'),
+                      child: TapScaleWrapper(
+                        onPressed: widget.onAddButtonPressed,
+                        child: ElevatedButton(
+                          onPressed: () {}, // Dummy, handled by wrapper
+                          style: Theme.of(context).elevatedButtonTheme.style,
+                          child: const Text('Agregar'),
+                        ),
                       ),
                     ),
                   ],


### PR DESCRIPTION
…o ProductCard

This commit introduces UI mockups for key personal account features, including a login screen and a profile screen structure. It also adds a UI-only favorite toggle icon to the ProductCard.

Key changes:

**Phase 1: Login Screen UI**
1.  **`LoginScreen` (`lib/screens/auth/login_screen.dart`)**:
    *   I created a new screen with app logo, welcome text, and a prominent
      "Sign in with Google" button. The button's action is currently a
      placeholder (prints to console and shows a SnackBar).

2.  **Navigation to `LoginScreen`**:
    *   I updated `ProfilePlaceholderView` (`lib/views/profile/profile_placeholder_view.dart`)
      with more relevant text and an "Iniciar Sesión / Registrarse"
      button that navigates to the new `LoginScreen`.

**Phase 2: Profile Screen UI (Mockup for Logged-In State)**
3.  **`ProfileScreen` (`lib/views/profile/profile_screen.dart`)**:
    *   I created a new screen to represent a logged-in user's profile.
    *   It includes a header with placeholders for a profile picture, user name, and email.
    *   It displays a list of tappable options: "Mis Favoritos," "Historial de Pedidos,"
      "Métodos de Pago," "Configuración," and a "Cerrar Sesión" button.
    *   Navigation from these options leads to new, simple placeholder screens.
    *   The logout button simulates navigation back to `LoginScreen` and clears the stack.

4.  **Placeholder Sub-Screens for Profile Sections**:
    *   I created `FavoritesScreenPlaceholder.dart`, `OrderHistoryScreenPlaceholder.dart`,
      and `PaymentMethodsScreenPlaceholder.dart` in `lib/views/profile/`.
      These are simple `Scaffold` + `AppBar` + `Text` widgets.

5.  **`MainAppShell` "Perfil" Tab**:
    *   Conceptually complete: The "Perfil" tab in `MainAppShell` shows
      `ProfilePlaceholderView`, which correctly initiates the login flow by
      navigating to `LoginScreen`. (I made no direct code change to `MainAppShell`
      in this phase beyond what was done for bottom nav setup).

**Phase 3: Favorite Icon on Product Card (UI Only)**
6.  **`ProductCard` Update (`lib/widgets/product_card.dart`)**:
    *   I converted `ProductCard` to a `StatefulWidget`.
    *   I added an `IconButton` (heart icon) to the top-right of the product image.
    *   The icon toggles between `Icons.favorite_border` and `Icons.favorite`
      (with color change) based on a local `_isFavorite` state.
    *   Tapping the icon currently only updates this local UI state and prints
      a debug message; no data persistence is implemented.

These changes lay the groundwork for future implementation of full user account functionality by providing the initial UI structure.