### PR TITLE
feat: Implement UI mockup for checkout flow

### DIFF
--- a/lib/screens/checkout/checkout_screen.dart
+++ b/lib/screens/checkout/checkout_screen.dart
@@ -1,0 +1,309 @@
+// lib/screens/checkout/checkout_screen.dart
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../providers/cart_provider.dart';
+import '../../core/constants/colors.dart';
+// Import for OrderConfirmationScreen (will be created later)
+// For now, this import is commented out, navigation will be placeholder.
+import 'order_confirmation_screen.dart';
+import '../main_app_shell.dart'; // For navigating back to home
+
+// DeliveryOption and PaymentMethod classes remain the same
+class DeliveryOption {
+  final String id;
+  final String title;
+  final String subtitle;
+  final double price;
+
+  const DeliveryOption({
+    required this.id,
+    required this.title,
+    required this.subtitle,
+    required this.price,
+  });
+}
+class PaymentMethod {
+  final String id;
+  final String title;
+  final IconData icon;
+
+  const PaymentMethod({
+    required this.id,
+    required this.title,
+    required this.icon,
+  });
+}
+
+class CheckoutScreen extends StatefulWidget {
+  const CheckoutScreen({super.key});
+  @override
+  State<CheckoutScreen> createState() => _CheckoutScreenState();
+}
+
+class _CheckoutScreenState extends State<CheckoutScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _streetController = TextEditingController();
+  final _apartmentController = TextEditingController();
+  final _cityController = TextEditingController();
+  final _postalCodeController = TextEditingController();
+  final _instructionsController = TextEditingController();
+
+  final List<DeliveryOption> _deliveryOptions = const [
+    DeliveryOption(id: 'standard', title: 'Envío Standard', subtitle: 'Entrega en 3-5 días hábiles', price: 3500),
+    DeliveryOption(id: 'express', title: 'Envío Express', subtitle: 'Entrega en 1-2 días hábiles', price: 7000),
+  ];
+  DeliveryOption? _selectedDeliveryOption;
+
+  final List<PaymentMethod> _paymentMethods = const [
+    PaymentMethod(id: 'cash', title: 'Efectivo al Entregar', icon: Icons.money_outlined),
+    PaymentMethod(id: 'card_mock', title: 'Tarjeta de Crédito/Débito (Simulado)', icon: Icons.credit_card_outlined),
+  ];
+  PaymentMethod? _selectedPaymentMethod;
+
+  @override
+  void initState() {
+    super.initState();
+    if (_deliveryOptions.isNotEmpty) {
+      _selectedDeliveryOption = _deliveryOptions.first;
+    }
+    if (_paymentMethods.isNotEmpty) {
+      _selectedPaymentMethod = _paymentMethods.first;
+    }
+  }
+  @override
+  void dispose() {
+    _streetController.dispose();
+    _apartmentController.dispose();
+    _cityController.dispose();
+    _postalCodeController.dispose();
+    _instructionsController.dispose();
+    super.dispose();
+  }
+
+  // Helper to calculate grand total
+  double _calculateGrandTotal(CartProvider cart) {
+    double deliveryFee = _selectedDeliveryOption?.price ?? 0.0;
+    return cart.totalPrice + deliveryFee;
+  }
+
+  void _handleConfirmOrder(CartProvider cart) {
+    if (_formKey.currentState!.validate()) { // Basic form validation
+      // In a real app: process payment, save order to backend
+      print('Order Confirmed!');
+      print('Address: ${_streetController.text}, ${_cityController.text}');
+      print('Delivery: ${_selectedDeliveryOption?.title}');
+      print('Payment: ${_selectedPaymentMethod?.title}');
+      print('Grand Total: ${_calculateGrandTotal(cart)}');
+
+      // Clear cart
+      // Use context.read<CartProvider>() if you need to call methods on a provider
+      // from within a callback where the context might be tricky,
+      // or pass the cart provider instance directly as done here.
+      cart.clearCart();
+
+      // Show dialog first, then navigate.
+      // Capture the context before showDialog if it's inside an async gap
+      // For this case, it's synchronous before the navigation so current context is fine.
+      // Remove the direct navigation to MainAppShell.
+      // The AlertDialog's OK button will handle navigation.
+
+      showDialog(
+          context: context, // Use the CheckoutScreen's context
+          barrierDismissible: false,
+          builder: (BuildContext dialogCtx) {
+            return AlertDialog(
+              title: const Text('¡Pedido Confirmado!'),
+              content: const Text('Gracias por tu compra. Tu pedido está siendo procesado.'),
+              actions: <Widget>[
+                TextButton(
+                  child: const Text('OK'),
+                  onPressed: () {
+                    Navigator.of(dialogCtx).pop(); // Dismiss dialog
+                    // NOW navigate to OrderConfirmationScreen, clearing stack
+                    Navigator.of(context).pushAndRemoveUntil( // Use CheckoutScreen's context for navigation
+                      MaterialPageRoute(builder: (context) => const OrderConfirmationScreen()),
+                      (Route<dynamic> route) => false,
+                    );
+                  },
+                ),
+              ],
+            );
+          },
+        );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Por favor, completa los campos requeridos.')),
+      );
+    }
+  }
+
+
+  @override
+  Widget build(BuildContext context) {
+    final cart = context.watch<CartProvider>();
+    final TextTheme textTheme = Theme.of(context).textTheme;
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final double grandTotal = _calculateGrandTotal(cart);
+
+    return Scaffold(
+      appBar: AppBar( title: const Text('Confirmar Pedido'), ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              // 1. Order Summary
+              Text('Resumen del Pedido', style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(12.0),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text('Total a Pagar (Productos):', style: textTheme.titleMedium),
+                      Text( '\$${cart.totalPrice.toStringAsFixed(0)}', style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 24.0),
+
+              // 2. Delivery Address
+              Text('Dirección de Envío', style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 12.0),
+              _buildTextFormField(controller: _streetController, labelText: 'Calle y Número', hintText: 'Ej: Av. Siempreviva 742'),
+              _buildTextFormField(controller: _apartmentController, labelText: 'Departamento, Casa, etc. (Opcional)', hintText: 'Ej: Depto 123, Casa B'),
+              _buildTextFormField(controller: _cityController, labelText: 'Ciudad / Comuna', hintText: 'Ej: Springfield'),
+              _buildTextFormField(controller: _postalCodeController, labelText: 'Código Postal (Opcional)', hintText: 'Ej: 1234567', keyboardType: TextInputType.number),
+              _buildTextFormField(controller: _instructionsController, labelText: 'Instrucciones de Entrega (Opcional)', hintText: 'Ej: Dejar en conserjería, llamar al llegar', maxLines: 3),
+              const SizedBox(height: 24.0),
+
+              // 3. Delivery Options Section
+              Text('Opciones de Envío', style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8.0),
+              Card(
+                child: Column(
+                  children: _deliveryOptions.map((option) {
+                    return RadioListTile<DeliveryOption>(
+                      title: Text(option.title, style: textTheme.titleMedium),
+                      subtitle: Text('${option.subtitle} (+\$${option.price.toStringAsFixed(0)})', style: textTheme.bodyMedium),
+                      value: option,
+                      groupValue: _selectedDeliveryOption,
+                      onChanged: (DeliveryOption? value) {
+                        setState(() { _selectedDeliveryOption = value; });
+                      },
+                      activeColor: colorScheme.primary,
+                    );
+                  }).toList(),
+                ),
+              ),
+              const SizedBox(height: 24.0),
+
+              // 4. Payment Methods Section
+              Text('Método de Pago', style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8.0),
+              Card(
+                child: Column(
+                  children: _paymentMethods.map((method) {
+                    return RadioListTile<PaymentMethod>(
+                      title: Text(method.title, style: textTheme.titleMedium),
+                      secondary: Icon(method.icon, color: AppColors.textMuted, size: 28),
+                      value: method,
+                      groupValue: _selectedPaymentMethod,
+                      onChanged: (PaymentMethod? value) {
+                        setState(() { _selectedPaymentMethod = value; });
+                      },
+                      activeColor: colorScheme.primary,
+                    );
+                  }).toList(),
+                ),
+              ),
+              const SizedBox(height: 24.0),
+
+              // --- 5. Final Order Review ---
+              Text('Revisión Final', style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8.0),
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Column(
+                    children: [
+                      _buildSummaryRow(context, 'Subtotal Productos:', '\$${cart.totalPrice.toStringAsFixed(0)}'),
+                      const SizedBox(height: 8),
+                      _buildSummaryRow(context, 'Costo de Envío:', '+\$${(_selectedDeliveryOption?.price ?? 0.0).toStringAsFixed(0)}'),
+                      const Divider(height: 20, thickness: 1),
+                      _buildSummaryRow(
+                        context,
+                        'Total General:',
+                        '\$${grandTotal.toStringAsFixed(0)}',
+                        isTotal: true
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              // --- End Final Order Review ---
+              const SizedBox(height: 32.0),
+
+              // --- 6. Confirm and Pay Button ---
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 16.0),
+                  ),
+                  onPressed: cart.itemsList.isEmpty ? null : () => _handleConfirmOrder(cart),
+                  child: const Text('CONFIRMAR Y PAGAR (SIMULADO)'),
+                ),
+              ),
+              // --- End Confirm and Pay Button ---
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSummaryRow(BuildContext context, String label, String value, {bool isTotal = false}) {
+    final TextTheme textTheme = Theme.of(context).textTheme;
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(label, style: isTotal ? textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold) : textTheme.titleMedium),
+        Text(
+          value,
+          style: isTotal
+            ? textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold, color: colorScheme.secondary)
+            : textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold)
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTextFormField({
+    required TextEditingController controller,
+    required String labelText,
+    String? hintText,
+    TextInputType keyboardType = TextInputType.text,
+    int maxLines = 1,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: TextFormField(
+        controller: controller,
+        decoration: InputDecoration(
+          labelText: labelText,
+          hintText: hintText,
+          border: const OutlineInputBorder(),
+        ),
+        keyboardType: keyboardType,
+        maxLines: maxLines,
+      ),
+    );
+  }
+}

--- a/lib/screens/checkout/order_confirmation_screen.dart
+++ b/lib/screens/checkout/order_confirmation_screen.dart
@@ -1,0 +1,65 @@
+// lib/screens/checkout/order_confirmation_screen.dart
+import 'package:flutter/material.dart';
+import '../main_app_shell.dart'; // To navigate back to home
+import '../../core/constants/colors.dart'; // For AppColors if needed
+
+class OrderConfirmationScreen extends StatelessWidget {
+  // Optional: Could accept an order ID or details to display
+  // final String orderId;
+  // const OrderConfirmationScreen({super.key, required this.orderId});
+
+  const OrderConfirmationScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme textTheme = Theme.of(context).textTheme;
+    // final ColorScheme colorScheme = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      // No AppBar, to make it feel like a final confirmation/modal-like page over everything
+      backgroundColor: AppColors.primaryDark, // Or use theme.scaffoldBackgroundColor
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: <Widget>[
+              Icon(
+                Icons.check_circle_outline_rounded,
+                color: AppColors.success, // Or colorScheme.primary
+                size: 100,
+              ),
+              const SizedBox(height: 24),
+              Text(
+                '¡Gracias por tu pedido!',
+                style: textTheme.headlineMedium?.copyWith(color: AppColors.textLight),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                'Tu orden ha sido recibida y está siendo procesada.', // Placeholder order ID
+                // 'Tu orden #12345 ha sido recibida y está siendo procesada.', // Example with order ID
+                style: textTheme.titleMedium?.copyWith(color: AppColors.textMuted),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 40),
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 16),
+                ),
+                onPressed: () {
+                  Navigator.of(context).pushAndRemoveUntil(
+                    MaterialPageRoute(builder: (context) => const MainAppShell()),
+                    (Route<dynamic> route) => false, // Clear all routes before it
+                  );
+                },
+                child: Text('VOLVER AL INICIO', style: textTheme.labelLarge),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/cart/cart_screen.dart
+++ b/lib/views/cart/cart_screen.dart
@@ -2,29 +2,29 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../providers/cart_provider.dart';
-import '../../models/cart_item_model.dart';
-import '../../core/constants/colors.dart'; // For styling
+import '../../models/cart_item_model.dart'; // Keep for type, though not directly instantiated
+import '../../core/constants/colors.dart';
+import '../../screens/checkout/checkout_screen.dart'; // Import CheckoutScreen
 
 class CartScreen extends StatelessWidget {
   const CartScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final cart = context.watch<CartProvider>(); // Watch for changes
+    final cart = context.watch<CartProvider>();
     final TextTheme textTheme = Theme.of(context).textTheme;
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
 
     return Scaffold(
       appBar: AppBar(
         title: const Text('Mi Carrito'),
-        automaticallyImplyLeading: false, // As it's a tab in MainAppShell
+        automaticallyImplyLeading: false,
         actions: [
           if (cart.itemsList.isNotEmpty)
             IconButton(
               icon: const Icon(Icons.delete_sweep_outlined),
               tooltip: 'Vaciar Carrito',
               onPressed: () {
-                // Confirmation Dialog before clearing cart
                 showDialog(
                   context: context,
                   builder: (ctx) => AlertDialog(
@@ -33,22 +33,16 @@ class CartScreen extends StatelessWidget {
                     actions: <Widget>[
                       TextButton(
                         child: const Text('Cancelar'),
-                        onPressed: () {
-                          Navigator.of(ctx).pop();
-                        },
+                        onPressed: () { Navigator.of(ctx).pop(); },
                       ),
                       TextButton(
                         child: Text('Vaciar', style: TextStyle(color: colorScheme.error)),
-                        onPressed: () {
-                          cart.clearCart(); // Use read here as we are in a callback
-                          // Provider.of<CartProvider>(context, listen: false).clearCart();
-                          Navigator.of(ctx).pop();
-                        },
+                        onPressed: () { cart.clearCart(); Navigator.of(ctx).pop(); },
                       ),
                     ],
                   ),
                 );
-              },
+              }
             ),
         ],
       ),
@@ -73,17 +67,15 @@ class CartScreen extends StatelessWidget {
                     itemCount: cart.itemsList.length,
                     itemBuilder: (ctx, i) {
                       final cartItem = cart.itemsList[i];
-                      return Card( // Wrap each item in a Card for better visual separation
+                      return Card(
                         margin: const EdgeInsets.symmetric(vertical: 6.0),
-                        // elevation: 2, // Uses CardTheme from AppTheme
                         child: ListTile(
                           leading: SizedBox(
-                            width: 70, // Fixed width for image container
-                            height: 70, // Fixed height for image container
+                            width: 70,
+                            height: 70,
                             child: ClipRRect(
                               borderRadius: BorderRadius.circular(8.0),
                               child: Image.asset(
-                                // Basic image path derivation, assuming product.imagen exists
                                 'assets/images/products/${cartItem.product.subcategoria?.toLowerCase().replaceAll(' ', '_') ?? 'general'}/${cartItem.product.imagen ?? '${cartItem.product.id.toLowerCase()}.jpg'}',
                                 fit: BoxFit.cover,
                                 errorBuilder: (context, error, stackTrace) => Container(
@@ -113,9 +105,7 @@ class CartScreen extends StatelessWidget {
                               IconButton(
                                 icon: const Icon(Icons.remove_circle_outline, size: 24),
                                 color: AppColors.primaryRed,
-                                onPressed: () {
-                                  cart.updateItemQuantity(cartItem.id, cartItem.quantity - 1);
-                                },
+                                onPressed: () { cart.updateItemQuantity(cartItem.id, cartItem.quantity - 1); },
                                 splashRadius: 20,
                                 padding: EdgeInsets.zero,
                                 constraints: const BoxConstraints(),
@@ -124,9 +114,7 @@ class CartScreen extends StatelessWidget {
                               IconButton(
                                 icon: const Icon(Icons.add_circle_outline, size: 24),
                                 color: AppColors.primaryRed,
-                                onPressed: () {
-                                  cart.updateItemQuantity(cartItem.id, cartItem.quantity + 1);
-                                },
+                                onPressed: () { cart.updateItemQuantity(cartItem.id, cartItem.quantity + 1); },
                                 splashRadius: 20,
                                 padding: EdgeInsets.zero,
                                 constraints: const BoxConstraints(),
@@ -139,7 +127,6 @@ class CartScreen extends StatelessWidget {
                     separatorBuilder: (ctx, i) => const Divider(height: 1),
                   ),
                 ),
-                // Total and Checkout Button Area
                 Padding(
                   padding: const EdgeInsets.all(16.0),
                   child: Column(
@@ -148,9 +135,7 @@ class CartScreen extends StatelessWidget {
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: <Widget>[
                           Text('Total General:', style: textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold)),
-                          Text(
-                            '\$${cart.totalPrice.toStringAsFixed(0)}',
-                            style: textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold, color: colorScheme.secondary),
+                          Text( '\$${cart.totalPrice.toStringAsFixed(0)}', style: textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold, color: colorScheme.secondary),
                           ),
                         ],
                       ),
@@ -160,14 +145,12 @@ class CartScreen extends StatelessWidget {
                         child: ElevatedButton(
                           style: ElevatedButton.styleFrom(
                             padding: const EdgeInsets.symmetric(vertical: 16.0),
-                            // backgroundColor: AppColors.primaryRed, // From theme
-                            // textStyle: textTheme.labelLarge, // From theme
                           ),
                           onPressed: cart.itemsList.isEmpty ? null : () {
-                            // Placeholder for checkout action
-                            print('Checkout button pressed. Total: ${cart.totalPrice}');
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(content: Text('Proceso de pago (pendiente).')),
+                            // MODIFIED: Navigate to CheckoutScreen
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(builder: (context) => const CheckoutScreen()),
                             );
                           },
                           child: const Text('PROCEDER AL PAGO'),


### PR DESCRIPTION
This commit introduces the UI screens and navigation logic for a multi-step checkout process, from cart to order confirmation. All payment and order processing is simulated.

Key changes:

1.  **`CheckoutScreen` (`lib/screens/checkout/checkout_screen.dart`)**:
    *   Created a new stateful screen that serves as the main checkout page.
    *   Displays sections for:
        *   Order Summary (showing total from `CartProvider`).
        *   Delivery Address (using `TextFormField`s within a `Form`).
        *   Delivery Options (using `RadioListTile`s with placeholder prices).
        *   Payment Methods (using `RadioListTile`s for mocked options like
          "Efectivo" and "Tarjeta (Simulado)").
        *   Final Order Review (cart subtotal, selected delivery fee, grand total).
    *   Includes a "Confirmar Pedido y Pagar (Simulado)" button.
    *   On confirmation (after basic form validation placeholder):
        *   Prints order details to console.
        *   Clears the cart via `CartProvider.clearCart()`.
        *   Shows an "¡Pedido Confirmado!" `AlertDialog`.
        *   Navigates to `OrderConfirmationScreen` upon dialog dismissal,
          clearing the previous navigation stack.

2.  **`OrderConfirmationScreen` (`lib/screens/checkout/order_confirmation_screen.dart`)**:
    *   New stateless screen displaying a "¡Gracias por tu pedido!" message,
      success icon, and a placeholder for an order number.
    *   Includes a "VOLVER AL INICIO" button that navigates back to
      `MainAppShell` (Home tab), clearing the checkout navigation stack.

3.  **Updated `CartScreen` Navigation (`lib/views/cart/cart_screen.dart`)**:
    *   The "PROCEDER AL PAGO" button now navigates to the new `CheckoutScreen`.

This provides a comprehensive UI mockup for the checkout experience, allowing you to input necessary information, review your order, and receive a simulated order confirmation.