### PR TITLE
fix: Correct syntax error in ProductDetailDialog after Hero comment

### DIFF
--- a/lib/views/product/product_detail_dialog.dart
+++ b/lib/views/product/product_detail_dialog.dart
@@ -144,7 +144,7 @@ class _ProductDetailDialogState extends State<ProductDetailDialog> {
                 children: <Widget>[
                   // Hero(
                   //   tag: 'hero_product_image_${widget.product.id}',
-                    child: ClipRRect(
+                  ClipRRect(
                       borderRadius: BorderRadius.only( topLeft: dialogBorderRadius.topLeft, topRight: dialogBorderRadius.topRight,),
                       child: SizedBox(
                         height: 180,


### PR DESCRIPTION
I resolved a syntax error in `lib/views/product/product_detail_dialog.dart` that occurred after commenting out the `Hero` widget around the main product image.

The error was caused by an extraneous `child:` named parameter remaining before the `ClipRRect` widget, which is not valid as a direct item in a `Column`'s `children` list.

I removed the `child:` keyword, and the `ClipRRect` is now correctly positioned as a direct child widget. This fixes the build error.